### PR TITLE
Features, fixes and code refactors

### DIFF
--- a/addons/godot-version-management/godot_version_manager.gd
+++ b/addons/godot-version-management/godot_version_manager.gd
@@ -83,7 +83,7 @@ func _update_export_presets() -> void:
 
 		# Update Windows exports configs
 		if export_config.get_value(section, "platform") == "Windows Desktop":
-			var windows_version_setting := "0." + version_setting if version_setting.split(".").size() <= 3 else version_setting
+			var windows_version_setting := version_setting + ".0" if version_setting.split(".").size() == 3 else version_setting
 			export_config.set_value(section + ".options", 'application/file_version', windows_version_setting)
 			export_config.set_value(section + ".options", 'application/product_version', windows_version_setting)
 

--- a/addons/godot-version-management/godot_version_manager.gd
+++ b/addons/godot-version-management/godot_version_manager.gd
@@ -2,77 +2,104 @@
 tool
 extends EditorPlugin
 
-const PLUGIN_NAME = "Godot-Version-Manager"
-const DEBUG = true
-# Use same name as https://github.com/godotengine/godot/pull/35555
-const PROJECT_VERSION_SETTING = "application/config/version"
-const PROJECT_BUILD_SETTING = "application/config/build"
-const EXPORT_PRESETS_FILE = "res://export_presets.cfg" 
-var current_version
-var current_build
 
-func _enter_tree():
+# Constants
+const PLUGIN_NAME := "Godot-Version-Manager"
+const DEBUG := true
+# Use same setting as https://github.com/godotengine/godot/pull/35555
+const PROJECT_VERSION_SETTING := "application/config/version"
+const PROJECT_BUILD_SETTING := "application/config/build"
+const EXPORT_PRESETS_FILE := "res://export_presets.cfg"
+
+
+# Variables
+var current_version: String
+var current_build: int
+
+
+# Built-in overrides
+func _enter_tree() -> void:
 	if not ProjectSettings.has_setting(PROJECT_VERSION_SETTING):
 		ProjectSettings.set_setting(PROJECT_VERSION_SETTING, "0.0.1")
+
 	if not ProjectSettings.has_setting(PROJECT_BUILD_SETTING):
 		ProjectSettings.set_setting(PROJECT_BUILD_SETTING, 1)
+
 	current_version = ProjectSettings.get_setting(PROJECT_VERSION_SETTING)
 	current_build = ProjectSettings.get_setting(PROJECT_BUILD_SETTING)
 
 
-func _exit_tree():
+func _exit_tree() -> void:
 	# Do not remove the verson config, may conflict with https://github.com/godotengine/godot/pull/35555
 	pass
 
 
-func apply_changes():
+func apply_changes() -> void:
 	_update_export_presets()
 
 
-func save_external_data():
+func save_external_data() -> void:
 	_update_export_presets()
 
 
-func _update_export_presets():
-	# If config version changed, update all exports
-	if ProjectSettings.get_setting(PROJECT_VERSION_SETTING) != current_version:
-		var export_config: ConfigFile = ConfigFile.new()
-		var err = export_config.load(EXPORT_PRESETS_FILE)
-		if err == OK:
-			# Loop limited to 100 exports
-			for i in range(0, 100):
-				var section = "preset." + str(i)
-				if export_config.has_section(section):
-					plugin_log("Update Export " + export_config.get_value(section, "platform"))
-					# Update Android exports configs
-					if export_config.get_value(section, "platform") == "Android":
-						export_config.set_value(section + ".options", 'version/name', ProjectSettings.get_setting(PROJECT_VERSION_SETTING))
-						export_config.set_value(section + ".options", 'version/code', ProjectSettings.get_setting(PROJECT_BUILD_SETTING))
-					if export_config.get_value(section, "platform") == "iOS" or export_config.get_value(section, "platform") == "Mac OSX":
-						export_config.set_value(section + ".options", 'application/short_version', ProjectSettings.get_setting(PROJECT_VERSION_SETTING))
-						export_config.set_value(section + ".options", 'application/version', ProjectSettings.get_setting(PROJECT_BUILD_SETTING))
-					if export_config.get_value(section, "platform") == "UWP":
-						# TODO parsing of version to minor/major
-						pass
-					if export_config.get_value(section, "platform") == "Windows Desktop":
-						export_config.set_value(section + ".options", 'application/file_version', ProjectSettings.get_setting(PROJECT_VERSION_SETTING))
-						export_config.set_value(section + ".options", 'application/product_version', ProjectSettings.get_setting(PROJECT_VERSION_SETTING))
-				else:
-					break
-			err = export_config.save(EXPORT_PRESETS_FILE)
-			ProjectSettings.save()
-			if err == OK:
-				plugin_log("All exports updated")
-			else:
-				plugin_log("Error saving " + EXPORT_PRESETS_FILE + ", exports not updated")
-		else:
-			plugin_log('Error open ' + EXPORT_PRESETS_FILE)
+# Private methods
+func _update_export_presets() -> void:
+	var version_setting: String = ProjectSettings.get_setting(PROJECT_VERSION_SETTING)
+	var build_setting: int = ProjectSettings.get_setting(PROJECT_BUILD_SETTING)
+
+	# If config version not changed, do not update all exports
+	if version_setting == current_version:
+		return
+
+	var export_config := ConfigFile.new()
+	var err := export_config.load(EXPORT_PRESETS_FILE)
+
+	if err != OK:
+		_plugin_log('Error open ' + EXPORT_PRESETS_FILE)
+		return
+
+	# Loop limited to 100 exports
+	for i in range(0, 100):
+		var section := "preset." + str(i)
+
+		if not export_config.has_section(section):
+			break
+
+		_plugin_log("Update Export " + export_config.get_value(section, "platform"))
+
+		# Update Android exports configs
+		if export_config.get_value(section, "platform") == "Android":
+			export_config.set_value(section + ".options", 'version/name', version_setting)
+			export_config.set_value(section + ".options", 'version/code', build_setting)
+
+		# Update Apple exports configs
+		if export_config.get_value(section, "platform") == "iOS" or export_config.get_value(section, "platform") == "Mac OSX":
+			export_config.set_value(section + ".options", 'application/short_version', version_setting)
+			export_config.set_value(section + ".options", 'application/version', build_setting)
+
+		if export_config.get_value(section, "platform") == "UWP":
+			# TODO parsing of version to minor/major
+			pass
+
+		# Update Windows exports configs
+		if export_config.get_value(section, "platform") == "Windows Desktop":
+			var windows_version_setting := "0." + version_setting if version_setting.split(".").size() <= 3 else version_setting
+			export_config.set_value(section + ".options", 'application/file_version', windows_version_setting)
+			export_config.set_value(section + ".options", 'application/product_version', windows_version_setting)
+
+	err = export_config.save(EXPORT_PRESETS_FILE)
+	ProjectSettings.save()
+
+	if err != OK:
+		_plugin_log("Error saving " + EXPORT_PRESETS_FILE + ", exports not updated")
+		return
+
+	_plugin_log("All exports updated")
 
 
-func plugin_log(message):
+func _plugin_log(message: String) -> void:
 	if (DEBUG):
-		var time : Dictionary = OS.get_datetime()
-		var date_string : String = "%02d:%02d" % [time.hour, time.minute]
+		var time := Time.get_datetime_dict_from_system()
+		var date_string := "%02d:%02d" % [time.hour, time.minute]
 		print(date_string, " - ", PLUGIN_NAME, " - ", message)
-	
 

--- a/addons/godot-version-management/godot_version_manager.gd
+++ b/addons/godot-version-management/godot_version_manager.gd
@@ -125,15 +125,15 @@ func _parse_version(version: String, build: int) -> Dictionary:
 	var version_split := version.split(".")
 
 	# Do not generate major.minor.patch
-	if version_split.size() < 3:
+	if version_split.size() == 0:
 		return dict
 
-	var major := int(version_split[0])
-	var minor := int(version_split[1])
-	var patch := int(version_split[2])
+	var major := int(version_split[0]) if version_split.size() >= 1 else 0
+	var minor := int(version_split[1]) if version_split.size() >= 2 else 0
+	var patch := int(version_split[2]) if version_split.size() >= 3 else 0
 
 	# Generate build number from version string ('2.3.4' == 20304)
-	if not build or build < 0:
+	if build <= 0:
 		dict["build"] = int(str(major) + str(minor).pad_zeros(2) + str(patch).pad_zeros(2))
 
 	dict.merge({

--- a/addons/godot-version-management/godot_version_manager.gd
+++ b/addons/godot-version-management/godot_version_manager.gd
@@ -77,9 +77,15 @@ func _update_export_presets() -> void:
 			export_config.set_value(section + ".options", 'application/short_version', version_setting)
 			export_config.set_value(section + ".options", 'application/version', build_setting)
 
+		# Update UWP exports configs
 		if export_config.get_value(section, "platform") == "UWP":
-			# TODO parsing of version to minor/major
-			pass
+			var version_dict := _parse_version(version_setting)
+
+			if version_dict.size() > 0:
+				export_config.set_value(section + ".options", 'version/major', version_dict["major"])
+				export_config.set_value(section + ".options", 'version/minor', version_dict["minor"])
+				export_config.set_value(section + ".options", 'version/build', version_dict["patch"])
+				export_config.set_value(section + ".options", 'version/revision', 0)
 
 		# Update Windows exports configs
 		if export_config.get_value(section, "platform") == "Windows Desktop":
@@ -102,4 +108,17 @@ func _plugin_log(message: String) -> void:
 		var time := Time.get_datetime_dict_from_system()
 		var date_string := "%02d:%02d" % [time.hour, time.minute]
 		print(date_string, " - ", PLUGIN_NAME, " - ", message)
+
+
+func _parse_version(version: String) -> Dictionary:
+	var version_split := version.split(".")
+
+	if version_split.size() < 3:
+		return {}
+
+	return {
+		"major": int(version_split[0]),
+		"minor": int(version_split[1]),
+		"patch": int(version_split[2]),
+	}
 

--- a/addons/godot-version-management/plugin.cfg
+++ b/addons/godot-version-management/plugin.cfg
@@ -4,5 +4,5 @@ name="Godot-Version-Manager"
 description="Godot plugin to manage versions for exports.
 It centralize the version number in project."
 author="Erasor"
-version="1.0.0"
+version="1.0.1"
 script="godot_version_manager.gd"


### PR DESCRIPTION
- Comply with the [GDScript style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html)
- Add type hints to variables and constants and return types to functions
- Decrease amount of redundant calls (for example: `ProjectSettings.get_setting(PROJECT_VERSION_SETTING)`)
- Decrease indent levels on `_update_export_presets()`
- As `OS.get_datetime()` is deprecated, replace by `Time.get_datetime_dict_from_system()` on `_plugin_log()`
- Increase plugin version to `1.0.1`
- Generate `build` number from `version` string if `build` setting is less or equal `0` (`version` '2.3.4' generates `build` number `20304`)
- Implement TODO item: parse and set UWP from version
- On Windows exports it expects a version in the format `1.0.0.0` instead of [semver](https://semver.org/)'s `1.0.0`. This was fixed by adding `.0` at the end of current version, as noted [here](https://blog.inedo.com/nuget/package-versioning#:~:text=Alternative%3A%20Match%20Assembly%20Version%20and%20Package%20Version).
![image](https://user-images.githubusercontent.com/19820741/218746688-6c15fd82-bece-4483-a258-bf61b468470f.png)
